### PR TITLE
fix/git-basics static images

### DIFF
--- a/src/content/docs/solvro/git-basics/git.mdx
+++ b/src/content/docs/solvro/git-basics/git.mdx
@@ -70,22 +70,14 @@ Możemy również cofnąć i usunąć wszystkie zmiany do poprzedniego commita, 
 
 Jednakże, jeżeli wszystkie migawki łączyłby liniowy związek, nie możemy łatwo prototypować - jeśli cofnęlibyśmy się o kilka commitów i tam coś zmienili, ryzykowalibyśmy, że coś wywali się nam w najnowszym commit'cie.
 
-<img
-  src="/src/assets/tutorials/git-basics/one-branch-ex.png"
-  alt="Praca na jednej gałęzi"
-  style="margin-left:auto; margin-right:auto"
-/>
+![Przykład z jedną gałęzią w git](../../../../assets/tutorials/git-basics/one-branch-ex.png)
 
 Powyższy diagram pokazuje tworzenie commit'ów na jednej gałęzi.  
 Załóżmy, że potrzebujesz przetestować, jak wyglądają dwa różne rozwiązania - głupio byłoby w tym celu kopiować i izolować cały projekt czy usuwać jedne rozwiązanie na rzecz drugiego. Zamiast tego wystarczy utworzyć dwie nowe gałęzie.
 
 ### Gałęzie (ang. branches)
 
-<img
-  src="/src/assets/tutorials/git-basics/multi-branch-ex.png"
-  alt="Praca na jednej gałęzi"
-  style="margin-left:auto; margin-right:auto"
-/>
+![Przykład wielu gałęzi w git](../../../../assets/tutorials/git-basics/multi-branch-ex.png)
 
 Gałęzie pozwalają ci izolować swoją pracę na jednej wersji repozytorium, nie naruszając innych. Możesz na nich prototypować nowe funkcjonalności bez przeszkadzania innym i rozwalania sobie kodu na gałęzi _main_.  
 Aby utworzyć nową gałąź, używamy komendy:  
@@ -119,11 +111,8 @@ Musimy połączyć dwie gałęzie, a jest na to kilka sposobów.
 
 #### Merge
 
-<img
-  src="/src/assets/tutorials/git-basics/git-3-branches.png"
-  alt="Przykład mergowania z 3 gałęziami"
-  style="margin-left:auto; margin-right:auto"
-/>
+![Git repo z 3 gałęziami](../../../../assets/tutorials/git-basics/git-3-branches.png)
+
 _Przy większej ilości gałęzi, trudno odczytać coś z diagramu historii._
 
 W przypadku zwykłego merge zachowujemy szczegółowy dostęp do wszystkich zmian, jednak tworzymy _merge commits_,
@@ -136,11 +125,8 @@ FF merge nie tworzy merge commit'a i zwyczajnie przenosi zmiany na główną ga�
 
 #### Merge --squash
 
-<img
-  src="/src/assets/tutorials/git-basics/git-merge-squash-example.png"
-  alt="Przykład git merge z flagą --squash"
-  style="margin-left:auto; margin-right:auto"
-/>
+![git merge z flagą squash](../../../../assets/tutorials/git-basics/git-merge-squash-example.png)
+
 _Tworzymy jeden duży commit w miejscu scalenia gałęzi_ `git merge --squash
 feat_1` `git commit -m "abc"`
 
@@ -150,11 +136,7 @@ Pozwala to zachować liniową historię, jednakże tracimy szczegóły na temat 
 
 #### Rebase
 
-<img
-  src="/src/assets/tutorials/git-basics/git-rebase-example.png"
-  alt="Przykład git rebase"
-  style="margin-left:auto; margin-right:auto"
-/>
+![Przykład git rebase](../../../../assets/tutorials/git-basics/git-rebase-example.png)
 _(będąc na gałęzi feat)_ `git rebase main`
 
 Git rebase "przenosi" początek naszej gałęzi na koniec gałęzi źródłowej.
@@ -177,11 +159,7 @@ Zdarza się, że scalając dwie gałęzie, które w międzyczasie były modyfiko
 Nie jest to nic strasznego, bo tak długo, jak rozumiemy kod, a zmiany nie były dużych rozmiarów rozwiązywanie konfliktów jest bardzo proste.
 W skonfliktowanych plikach znajdziemy takie oznaczenia:
 
-<img
-  src="/src/assets/tutorials/git-basics/git-conflict-example.png"
-  alt="Przykład konfliktow w git"
-  style="margin-left:auto; margin-right:auto"
-/>
+![Przykład konfliktów w git](../../../../assets/tutorials/git-basics/git-conflict-example.png)
 
 - HEAD - w tej sekcji są zmiany z gałęzi, na której się znajdujemy
 - Jest ona oddzielona od zmian z drugiej gałęzi za pomocą separatora "======="

--- a/src/content/docs/solvro/git-basics/github.mdx
+++ b/src/content/docs/solvro/git-basics/github.mdx
@@ -150,20 +150,12 @@ Kiedy wejdziemy w panel projektu na GitHub po wysłaniu zmian do zdalnego repo, 
 Po wejściu w nią zobaczymy pola na tytuł i opis requesta. Powinniśmy tu opisać, co dodajemy do projektu.  
 Poniżej tych pól wyświetlą nam się do podglądu zmiany w kodzie.
 
-<img
-  src="/src/assets/tutorials/git-basics/pull-request-1.png"
-  alt="Okienko pull request"
-  style="margin-left:auto; margin-right:auto"
-/>
+![](../../../../assets/tutorials/git-basics/pull-request-1.png)
 
 Może zdarzyć się tak, że przy dodawaniu PR pojawią się konflikty. Możemy znów sfetchować repo do siebie i naprawić je lokalnie, po czym wysłać z powrotem na upstream,
 ale do mniejszych PR w pełni wystarczający jest webowy edytor tekstowy GitHuba.
 
-<img
-  src="/src/assets/tutorials/git-basics/pull-request-2.png"
-  alt="Edytor konfliktow GitHub"
-  style="margin-left:auto; margin-right:auto"
-/>
+![](../../../../assets/tutorials/git-basics/pull-request-2.png)
 
 Kiedy już rozwiążemy konflikty, pojawi się nam opcja scalania gałęzi. Możemy tu wybrać metodę scalania (zwykłe, squash, rebase). Wystarczy zaznaczyć tę, która najbardziej
 nam pasuje i już. Gotowe! Zmerge'owaliśmy nasze zmiany do main. Jeżeli jesteśmy pewni, że wszystko działa tak, jak powinno - a na tym etapie powinniśmy być - to możemy usunąć zbędną gałąź.

--- a/src/content/docs/solvro/git-basics/github.mdx
+++ b/src/content/docs/solvro/git-basics/github.mdx
@@ -155,7 +155,7 @@ Poniżej tych pól wyświetlą nam się do podglądu zmiany w kodzie.
 Może zdarzyć się tak, że przy dodawaniu PR pojawią się konflikty. Możemy znów sfetchować repo do siebie i naprawić je lokalnie, po czym wysłać z powrotem na upstream,
 ale do mniejszych PR w pełni wystarczający jest webowy edytor tekstowy GitHuba.
 
-![Conflits in github editor](../../../../assets/tutorials/git-basics/pull-request-2.png)
+![Conflicts in github editor](../../../../assets/tutorials/git-basics/pull-request-2.png)
 
 Kiedy już rozwiążemy konflikty, pojawi się nam opcja scalania gałęzi. Możemy tu wybrać metodę scalania (zwykłe, squash, rebase). Wystarczy zaznaczyć tę, która najbardziej
 nam pasuje i już. Gotowe! Zmerge'owaliśmy nasze zmiany do main. Jeżeli jesteśmy pewni, że wszystko działa tak, jak powinno - a na tym etapie powinniśmy być - to możemy usunąć zbędną gałąź.

--- a/src/content/docs/solvro/git-basics/github.mdx
+++ b/src/content/docs/solvro/git-basics/github.mdx
@@ -150,12 +150,12 @@ Kiedy wejdziemy w panel projektu na GitHub po wysłaniu zmian do zdalnego repo, 
 Po wejściu w nią zobaczymy pola na tytuł i opis requesta. Powinniśmy tu opisać, co dodajemy do projektu.  
 Poniżej tych pól wyświetlą nam się do podglądu zmiany w kodzie.
 
-![](../../../../assets/tutorials/git-basics/pull-request-1.png)
+![Pull request edit window](../../../../assets/tutorials/git-basics/pull-request-1.png)
 
 Może zdarzyć się tak, że przy dodawaniu PR pojawią się konflikty. Możemy znów sfetchować repo do siebie i naprawić je lokalnie, po czym wysłać z powrotem na upstream,
 ale do mniejszych PR w pełni wystarczający jest webowy edytor tekstowy GitHuba.
 
-![](../../../../assets/tutorials/git-basics/pull-request-2.png)
+![Conflits in github editor](../../../../assets/tutorials/git-basics/pull-request-2.png)
 
 Kiedy już rozwiążemy konflikty, pojawi się nam opcja scalania gałęzi. Możemy tu wybrać metodę scalania (zwykłe, squash, rebase). Wystarczy zaznaczyć tę, która najbardziej
 nam pasuje i już. Gotowe! Zmerge'owaliśmy nasze zmiany do main. Jeżeli jesteśmy pewni, że wszystko działa tak, jak powinno - a na tym etapie powinniśmy być - to możemy usunąć zbędną gałąź.

--- a/src/content/docs/solvro/git-basics/intro.mdx
+++ b/src/content/docs/solvro/git-basics/intro.mdx
@@ -5,11 +5,7 @@ sidebar:
   order: 9
 ---
 
-<img
-  src="/src/assets/tutorials/git-basics/solvro_git_logo.png"
-  alt="Logo git w kolorystyce KN Solvro"
-  style="margin-left:auto; margin-right:auto"
-/>
+![Logo git w kolorystyce Solvro](../../../../assets/tutorials/git-basics/solvro-git-logo.png)
 
 Ten poradnik jest dla osób, które chcą nauczyć się lub odświeżyć swoją wiedzę z podstaw gita lub GitHuba. Omówimy tu ich podstawowe funkcje.
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Replaces HTML `img` tags with markdown image syntax in Git basics documentation files, updating image paths for consistency.
> 
>   - **Markdown Updates**:
>     - Replace HTML `img` tags with markdown image syntax in `git.mdx`, `github.mdx`, and `intro.mdx`.
>     - Update image paths to use relative paths in markdown syntax.
>   - **Files Affected**:
>     - `git.mdx`: Updated 6 image references.
>     - `github.mdx`: Updated 2 image references.
>     - `intro.mdx`: Updated 1 image reference.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fweb-solvro-docs&utm_source=github&utm_medium=referral)<sup> for f0250090baa9195d6c976976f0b68fa98a81944d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->