### PR TITLE
feat: add links to knowledge resources to backend onboarding section

### DIFF
--- a/src/content/docs/sections/Backend/Get started.mdx
+++ b/src/content/docs/sections/Backend/Get started.mdx
@@ -29,7 +29,7 @@ Jeśli chcesz do nas dołączyć, skontaktuj się z **przewodniczącym sekcji!**
 - Komunikacja to kluczowy element współpracy, tutaj dowiesz się jak skontaktować się ze swoim nowym zespołem [**Komunikacja**](https://docs.solvro.pl/communication)
 - Nie wstydź się nam pokazać swojego kodu! W tej sekcji dowiesz się gdzie oraz w jaki sposób umieszczać swoje rozwiązania [**Korzystanie z GitHub**](https://docs.solvro.pl/github)
 - Regularnie poszerzaj swoje zasoby wiedzy, czytając newsletter **ByteByteGo**, do którego link znajdziesz na naszym Discordzie
-- Posiadamy również [listę wiedzy](https://docs.google.com/spreadsheets/d/1UnjOh5TYgNiFBw9jsM6mJrp68uEdzeW3iIi6Ew0xfgQ/edit?gid=0#gid=0), w której znajdziesz jeszcze więcej przydanych linków i zasobów
+- Posiadamy również [listę wiedzy](https://docs.google.com/spreadsheets/d/1UnjOh5TYgNiFBw9jsM6mJrp68uEdzeW3iIi6Ew0xfgQ/edit?gid=0#gid=0), w której znajdziesz jeszcze więcej przydatnych linków i zasobów
 
 
 ## Nasze projekty

--- a/src/content/docs/sections/Backend/Get started.mdx
+++ b/src/content/docs/sections/Backend/Get started.mdx
@@ -24,9 +24,13 @@ Jeśli chcesz do nas dołączyć, skontaktuj się z **przewodniczącym sekcji!**
 
 ## Onboarding
 
+- Nie wiesz, gdzie zacząć? Zerknij na [roadmapę dla backendu](https://roadmap.sh/backend?r=backend-beginner)
 - Jak wcześniej wspomnieliśmy, w naszych projektach korzystamy z **Adonisa**, z którym koniecznie musisz się zapoznać [**AdonisJS**](https://docs.solvro.pl/sections/backend/adonis/)
 - Komunikacja to kluczowy element współpracy, tutaj dowiesz się jak skontaktować się ze swoim nowym zespołem [**Komunikacja**](https://docs.solvro.pl/communication)
 - Nie wstydź się nam pokazać swojego kodu! W tej sekcji dowiesz się gdzie oraz w jaki sposób umieszczać swoje rozwiązania [**Korzystanie z GitHub**](https://docs.solvro.pl/github)
+- Regularnie poszerzaj swoje zasoby wiedzy, czytając newsletter **ByteByteGo**, do którego link znajdziesz na naszym Discordzie
+- Posiadamy również [listę wiedzy](https://docs.google.com/spreadsheets/d/1UnjOh5TYgNiFBw9jsM6mJrp68uEdzeW3iIi6Ew0xfgQ/edit?gid=0#gid=0), w której znajdziesz jeszcze więcej przydanych linków i zasobów
+
 
 ## Nasze projekty
 


### PR DESCRIPTION
Zadanie https://github.com/Solvro/Solvro/issues/18#issuecomment-2801276678

Dodałem informację o ByteByteGo, excelu z listą wiedzy oraz roadmapy do paragrafu onboarding w sekcji backend 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Added links to backend roadmap, ByteByteGo newsletter, and knowledge list in onboarding section.
> 
>   - **Onboarding Section Updates**:
>     - Added link to [backend roadmap](https://roadmap.sh/backend?r=backend-beginner) for beginners.
>     - Included mention of **ByteByteGo** newsletter available on Discord for continuous learning.
>     - Added link to [knowledge list](https://docs.google.com/spreadsheets/d/1UnjOh5TYgNiFBw9jsM6mJrp68uEdzeW3iIi6Ew0xfgQ/edit?gid=0#gid=0) with useful resources.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fweb-solvro-docs&utm_source=github&utm_medium=referral)<sup> for 30b0eb0872c621db50f89f7a0fc2cb82bfbbeb6a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->