### PR TITLE
fix: link ledcube project

### DIFF
--- a/src/content/docs/projects/LEDCube/Handbook.mdx
+++ b/src/content/docs/projects/LEDCube/Handbook.mdx
@@ -120,7 +120,7 @@ Projekt ma znaczący wpływ na promocję innowacji na Politechnice Wrocławskiej
 
 Dokumentacja projektu jest otwarcie dostępna na platformach:
 
-- [Projekt na GitHubie](https://github.com/solvro/ledcube).
+- [Projekt na GitHubie](https://github.com/Solvro/hardware-led-cube).
 - [Szczegóły projektu na docs.solvro.pl](https://docs.solvro.pl).
 
 ### Plan na przyszłość


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update GitHub project link in `Handbook.mdx` for LEDCube documentation.
> 
>   - **Documentation**:
>     - Update GitHub project link in `Handbook.mdx` from `https://github.com/solvro/ledcube` to `https://github.com/Solvro/hardware-led-cube`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fweb-solvro-docs&utm_source=github&utm_medium=referral)<sup> for f31b7902bd3e5a37a1308431374687bc63f7fe7e. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->