### PR TITLE
2026/P001 Doprecyzowanie zawiadomienia o Zgromadzeniu Walnym

### DIFF
--- a/src/content/docs/solvro/Statute.mdx
+++ b/src/content/docs/solvro/Statute.mdx
@@ -227,7 +227,7 @@ description: Regulamin KN Solvro
 
 4. O obradach Zgromadzenia Zarząd zawiadamia Członków co najmniej 14 dni przed terminem Walnego Zgromadzenia Członków. Zawiadomienie:  
    4.1 Jest publikowane na oficjalnych kanałach komunikacyjnych Organizacji.  
-   4.2 Wskazuje datę, godzinę oraz miejsce obrad, a także porządek obrad.  
+   4.2 Wskazuje datę, godzinę, miejsce, a także porządek obrad.  
    4.3 Określa termin i sposób zgłaszania kandydatów do Zarządu.  
    4.4 Określa termin i sposób zgłaszania propozycji zmian w regulaminie.  
    4.5 Zawiera informację o aktualnej liście członków uprawnionych do głosowania.

--- a/src/content/docs/solvro/Statute.mdx
+++ b/src/content/docs/solvro/Statute.mdx
@@ -225,7 +225,12 @@ description: Regulamin KN Solvro
    3.3. Na wniosek Prezesa Koła.  
    3.4. Na wniosek Opiekuna Koła.
 
-4. O terminie i miejscu obrad Zgromadzenia Zarząd zawiadamia Członków co najmniej 14 dni przed terminem Walnego Zgromadzenia Członków.
+4. O obradach Zgromadzenia Zarząd zawiadamia Członków co najmniej 14 dni przed terminem Walnego Zgromadzenia Członków. Zawiadomienie:
+   4.1 Jest publikowane na oficjalnych kanałach komunikacyjnych Organizacji.
+   4.2 Wskazuje datę, godzinę oraz miejsce obrad, a także porządek obrad.
+   4.3 Określa termin i sposób zgłaszania kandydatów do Zarządu
+   4.4 Określa termin i sposób zgłaszania propozycji zmian w regulaminie.
+   4.5 Zawiera informację o aktualnej liście członków uprawnionych do głosowania.
 
 5. Na Zgromadzeniu każdemu Aktywnemu Członkowi (z zastrzeżeniem § 5 ust. 9) przysługuje jeden głos.
 

--- a/src/content/docs/solvro/Statute.mdx
+++ b/src/content/docs/solvro/Statute.mdx
@@ -225,11 +225,11 @@ description: Regulamin KN Solvro
    3.3. Na wniosek Prezesa Koła.  
    3.4. Na wniosek Opiekuna Koła.
 
-4. O obradach Zgromadzenia Zarząd zawiadamia Członków co najmniej 14 dni przed terminem Walnego Zgromadzenia Członków. Zawiadomienie:
-   4.1 Jest publikowane na oficjalnych kanałach komunikacyjnych Organizacji.
-   4.2 Wskazuje datę, godzinę oraz miejsce obrad, a także porządek obrad.
-   4.3 Określa termin i sposób zgłaszania kandydatów do Zarządu
-   4.4 Określa termin i sposób zgłaszania propozycji zmian w regulaminie.
+4. O obradach Zgromadzenia Zarząd zawiadamia Członków co najmniej 14 dni przed terminem Walnego Zgromadzenia Członków. Zawiadomienie:  
+   4.1 Jest publikowane na oficjalnych kanałach komunikacyjnych Organizacji.  
+   4.2 Wskazuje datę, godzinę oraz miejsce obrad, a także porządek obrad.  
+   4.3 Określa termin i sposób zgłaszania kandydatów do Zarządu.  
+   4.4 Określa termin i sposób zgłaszania propozycji zmian w regulaminie.  
    4.5 Zawiera informację o aktualnej liście członków uprawnionych do głosowania.
 
 5. Na Zgromadzeniu każdemu Aktywnemu Członkowi (z zastrzeżeniem § 5 ust. 9) przysługuje jeden głos.


### PR DESCRIPTION
## Checklista

- [x] utworzenie brancha z main
- [x] wprowadzenie proponowanych zmian
- [x] utworzenie PR jako draft do brancha main
- [x] nadanie numeru wg. obecnych draftów
- [x] przypisanie autorów jako assignees
- [x] przypisanie "proposal" jako label
- [x] wypełnienie opisu, celu oraz efektów
- [ ] uczestnictwo w dyskusji, wprowadzenie ewentualnych poprawek przez autorów
- [ ] zmiana draftu na pełną PR 18.03.2026
- [ ] czas na zgłaszanie kontrproposala w osobnej PR odwołujacej się do tej do 21.03.2026
- [ ] głosowanie nad proposalem 21.03.2026
- [ ] wdrożenie/odrzucenie PR

## Opis
Proposal doprecyzowuje ogłaszanie Zgromadzenia Walnego.  

## Cel / Uzasadnienie
Walne Zgromadzenie członków KN Solvro jest najwyższą władzą organizacji. Prawidłowy przebieg obrad wymaga kworum oraz zapewnienia członkom aktywnym pełnego dostępu do informacji. Dotychczasowe zapisy dotyczące zwoływania Walnego Zgromadzenia nie precyzowały wszystkich informacji ani sposobu ich przekazywania

## Efekty, jeśli przyjęty
 Zawiadomienie o kolejnych Zgromadzeniach będzie musiało:
  - być publikowane na oficjalnych kanałach komunikacyjnych Organizacji.  
  - wskazywać datę, godzinę oraz miejsce obrad, a także porządek obrad.  
 -  określać termin i sposób zgłaszania kandydatów do Zarządu.  
  - określać termin i sposób zgłaszania propozycji zmian w regulaminie.  
  - zawierać informację o aktualnej liście członków uprawnionych do głosowania.

## Efekty, jeśli odrzucony
Zostanie dotychczasowy zapis zobowiązujący Zarząd do zawiadomienia o terminie i miejscu obrad Zgromadzenia Zarząd co najmniej 14 dni przed terminem Walnego Zgromadzenia Członków.