### PR TITLE
 2026/P005 - Wprowadzenie okresu wsparcia nowego Zarządu

### DIFF
--- a/src/content/docs/solvro/Statute.mdx
+++ b/src/content/docs/solvro/Statute.mdx
@@ -245,7 +245,7 @@ description: Regulamin KN Solvro
 
 9. Oficjalne i pełne przekazanie władzy nowo wybranemu Zarządowi następuje najpóźniej 12 miesięcy od dnia objęcia władzy poprzez poprzedni Zarząd i nie później niż miesiąc od dnia wyboru nowego Zarządu. Konkretną datę dzienną ustala Zarząd w drodze uchwały, a następnie zawiadamia o niej Członków Koła, najpóźniej w dniu wyboru nowego Zarządu.
 
-9a. Po oficjalnym przekazaniu władzy członkowie ustępującego Zarządu są zobowiązani do pozostania dostępnymi dla nowego Zarządu przez okres co najmniej 2 miesięcy. W tym czasie udzielają wsparcia merytorycznego w zakresie pełnionych wcześniej funkcji, szczególności dotyczącego spraw niezakończonych w trakcie kadencji. Obowiązek ten ma charakter indywidualny i spoczywa na każdym członku ustępującego Zarządu w zakresie jego obszaru odpowiedzialności. Ustępujący Prezes pozostaje dodatkowo punktem kontaktowym dla nowego Zarządu w sprawach wymagających wiedzy o całokształcie działalności Koła.
+9a. Po oficjalnym przekazaniu władzy członkowie ustępującego Zarządu są zobowiązani do pozostania dostępnymi dla nowego Zarządu przez okres co najmniej 2 miesięcy. W tym czasie udzielają wsparcia merytorycznego w zakresie pełnionych wcześniej funkcji, w szczególności dotyczącego spraw niezakończonych w trakcie kadencji. Obowiązek ten ma charakter indywidualny i spoczywa na każdym członku ustępującego Zarządu, w granicach jego obszaru odpowiedzialności. Ustępujący Prezes pozostaje dodatkowo punktem kontaktowym dla nowego Zarządu w sprawach wymagających wiedzy o całokształcie działalności Koła.
 
 10. Mandat członka Zarządu wygasa w przypadku:  
     10.1. Złożenia pisemnej rezygnacji na ręce Prezesa Zarządu, lub w przypadku rezygnacji z funkcji Prezesa – na ręce Opiekuna.  

--- a/src/content/docs/solvro/Statute.mdx
+++ b/src/content/docs/solvro/Statute.mdx
@@ -202,6 +202,8 @@ description: Regulamin KN Solvro
 
 9. Oficjalne i pełne przekazanie władzy nowo wybranemu Zarządowi następuje najpóźniej 12 miesięcy od dnia objęcia władzy poprzez poprzedni Zarząd i nie później niż miesiąc od dnia wyboru nowego Zarządu. Konkretną datę dzienną ustala Zarząd w drodze uchwały, a następnie zawiadamia o niej Członków Koła, najpóźniej w dniu wyboru nowego Zarządu.
 
+9a. Po oficjalnym przekazaniu władzy członkowie ustępującego Zarządu są zobowiązani do pozostania dostępnymi dla nowego Zarządu przez okres co najmniej 2 miesięcy. W tym czasie udzielają wsparcia merytorycznego w zakresie pełnionych wcześniej funkcji, szczególności dotyczącego spraw niezakończonych w trakcie kadencji. Obowiązek ten ma charakter indywidualny i spoczywa na każdym członku ustępującego Zarządu w zakresie jego obszaru odpowiedzialności. Ustępujący Prezes pozostaje dodatkowo punktem kontaktowym dla nowego Zarządu w sprawach wymagających wiedzy o całokształcie działalności Koła.
+
 10. Mandat członka Zarządu wygasa w przypadku:  
     10.1. Złożenia pisemnej rezygnacji na ręce Prezesa Zarządu, lub w przypadku rezygnacji z funkcji Prezesa – na ręce Opiekuna.  
     10.2. Upłynięcia kadencji Zarządu.  


### PR DESCRIPTION
# 2026/P005 - Wprowadzenie okresu wsparcia nowego Zarządu

## Opis
Proposal wprowadza formalny obowiązek wsparcia nowego Zarządu przez ustępujących członków przez okres co najmniej 2 miesięcy od oficjalnego przekazania władzy.

## Cel / Uzasadnienie
Obecny Regulamin zobowiązuje Zarząd do "płynnego przekazania władzy" (§8 ust. 6.12), jednak nie precyzuje żadnych oczekiwań wobec ustępującego Zarządu po samym akcie przekazania. W praktyce nowy Zarząd często napotyka sprawy wymagające wiedzy i kontekstu poprzedników. Formalizacja okresu wsparcia zabezpiecza ciągłość działania Koła i zmniejsza ryzyko utraty wiedzy operacyjnej przy zmianie władzy.

## Efekty, jeśli przyjęty
Do §8 dodany zostaje ust. 9a:
Po oficjalnym przekazaniu władzy członkowie ustępującego Zarządu są zobowiązani do pozostania dostępnymi dla nowego Zarządu przez okres co najmniej 2 miesięcy. W tym czasie udzielają wsparcia merytorycznego w zakresie pełnionych wcześniej funkcji, szczególności dotyczącego spraw niezakończonych w trakcie kadencji. Obowiązek ten ma charakter indywidualny i spoczywa na każdym członku ustępującego Zarządu w zakresie jego obszaru odpowiedzialności. Ustępujący Prezes pozostaje dodatkowo punktem kontaktowym dla nowego Zarządu w sprawach wymagających wiedzy o całokształcie działalności Koła.

## Efekty, jeśli odrzucony
Regulamin pozostaje bez formalnego mechanizmu zapewnienia ciągłości wiedzy przy zmianie Zarządu. Ewentualne wsparcie ustępującego Zarządu pozostaje kwestią dobrej woli, nie zobowiązania.