### PR TITLE
2026/P006 Wprowadzenie obowiązku podpisania Oświadczenia o własności intelektualnej

### DIFF
--- a/src/content/docs/solvro/Statute.mdx
+++ b/src/content/docs/solvro/Statute.mdx
@@ -101,7 +101,8 @@ description: Regulamin KN Solvro
     10.2. Należytego dbania o zasoby i środki materialne KN Solvro.  
     10.3. Podporządkowania się postanowieniom niniejszego regulaminu, uchwalonego przez Walne Zgromadzenie, a także postanowieniom i uchwałom Zarządu.  
     10.4. Dbania o dobre imię Koła oraz Politechniki Wrocławskiej.  
-    10.5. Rzetelnego pełnienia przyjętych na siebie obowiązków.
+    10.5. Rzetelnego pełnienia przyjętych na siebie obowiązków.  
+    10.6. Złożenia podpisanego dokumentu „Oświadczenie o własności intelektualnej” w terminie 30 dni od dnia uzyskania członkostwa w KN Solvro.
 
 11. Utrata Członkostwa następuje wskutek:  
     11.1. Pisemnej rezygnacji złożonej Zarządowi Koła.  

--- a/src/content/docs/solvro/Statute.mdx
+++ b/src/content/docs/solvro/Statute.mdx
@@ -102,7 +102,7 @@ description: Regulamin KN Solvro
     10.3. Podporządkowania się postanowieniom niniejszego regulaminu, uchwalonego przez Walne Zgromadzenie, a także postanowieniom i uchwałom Zarządu.  
     10.4. Dbania o dobre imię Koła oraz Politechniki Wrocławskiej.  
     10.5. Rzetelnego pełnienia przyjętych na siebie obowiązków.  
-    10.6. Złożenia podpisanego dokumentu „Oświadczenie o własności intelektualnej” w terminie 30 dni od dnia uzyskania członkostwa w KN Solvro.
+    10.6. Złożenia podpisanego dokumentu „Oświadczenie o własności intelektualnej” w terminie 30 dni od dnia uzyskania członkostwa w KN Solvro. Treść zaświadczenia ustala Zarząd drogą uchwały we współpracy z działem prawnym i działem ochrony własności intelektualnej.
 
 11. Utrata Członkostwa następuje wskutek:  
     11.1. Pisemnej rezygnacji złożonej Zarządowi Koła.  


### PR DESCRIPTION
# Opis
Proposal jest uzupełnieniem obowiązków członków Solvro o podpisanie dokumentu "Oświadczenie o własności intelektualnej" w ciągu 30 dni od zostania członkiem Solvro.

# Cel / Uzasadnienie
Od listopada, po ustaleniach z działem prawnym PWr, wymagane jest podpisanie przez każdego członka koła dokumentu regulującego kwestie własności intelektualnej powstającej w ramach działalności Koła.

Dokument ten zapewnia, że:
- członkowie są autorami lub współautorami tworzonych w ramach Koła wyników oraz posiadają do nich prawa autorskie,
- przekazywane wyniki nie naruszają praw osób trzecich i mogą być swobodnie wykorzystywane przez Koło,
- KN Solvro uzyskuje szeroką, nieodpłatną licencję do korzystania z tych wyników,
- wyniki mogą być publicznie udostępniane, w szczególności na otwartych licencjach,
- inni członkowie Koła (obecni i przyszli) mogą rozwijać, modyfikować i wykorzystywać te wyniki bez ograniczeń,
- autor zobowiązuje się nie wykonywać wobec Koła autorskich praw osobistych,
- autor zrzeka się roszczeń wobec Koła związanych ze sposobem wykorzystania przekazanych wyników.

Dodanie odpowiedniego zapisu do Regulaminu ma na celu formalne uregulowanie tej kwestii oraz zapewnienie spójności dokumentacji Koła z obowiązującymi wymaganiami.

# Efekty, jeśli przyjęty
Do § 5 Członkostwo dodany zostaje pkt 10.6 w brzmieniu:
10. Członkowie KN Solvro są zobowiązani do:
...
**10.6. Złożenia podpisanego „Oświadczenia o własności intelektualnej” w terminie 30 dni od dnia uzyskania członkostwa w KN Solvro.**

W efekcie:
- obowiązek podpisania dokumentu staje się formalnym elementem członkostwa,
- Koło uzyskuje spójność z wymaganiami prawnymi PWr.

# Efekty, jeśli odrzucony
Obowiązek podpisania oświadczenia pozostanie praktyką, ale bez formalnego umocowania w Regulaminie.