### PR TITLE
2026/P008 – Zasady przechowywania prywatnego mienia

### DIFF
--- a/src/content/docs/solvro/Statute.mdx
+++ b/src/content/docs/solvro/Statute.mdx
@@ -103,13 +103,24 @@ description: Regulamin KN Solvro
     10.4. Dbania o dobre imię Koła oraz Politechniki Wrocławskiej.  
     10.5. Rzetelnego pełnienia przyjętych na siebie obowiązków.
 
-11. Utrata Członkostwa następuje wskutek:  
+11. Członkowie Koła mogą przetrzymywać swoje prywatne mienie
+w biurze, przy czym:
+    11.1. mienie to nie może utrudniać codziennego funkcjonowania
+    członków Koła;
+    11.2. członkowie Koła mają prawo przenieść pozostawione mienie
+    w inne miejsce na terenie biura, jeżeli utrudnia ono pracę lub narusza
+    zasady bezpieczeństwa;
+    11.3. Zarząd oraz członkowie Koła nie ponoszą odpowiedzialności
+    za pozostawione mienie prywatne oraz jego stan, z wyłączeniem
+    przypadków działania umyślnego.
+
+12. Utrata Członkostwa następuje wskutek:  
     11.1. Pisemnej rezygnacji złożonej Zarządowi Koła.  
     11.2. Wykluczenia na podstawie uchwały Zarządu Koła.  
     11.3. Braku zaangażowania w prace Koła.  
     11.4. Wykluczenia na podstawie uchwały Walnego Zgromadzenia.
 
-12. Od decyzji podjętej przez Zarząd na podstawie ust. 11 pkt. 11.2. – 11.3. niniejszego paragrafu przysługuje odwołanie do Walnego Zgromadzenia Członków w terminie 14 dni od daty jej otrzymania.
+13. Od decyzji podjętej przez Zarząd na podstawie ust. 11 pkt. 11.2. – 11.3. niniejszego paragrafu przysługuje odwołanie do Walnego Zgromadzenia Członków w terminie 14 dni od daty jej otrzymania.
 
 ---
 


### PR DESCRIPTION
### Opis:
Sformalizowanie i doprecyzowanie zasad przechowywania własnego mienia członków w biurze. 

### Cel:
Brak jasnych zasad może prowadzić do nieporozumień dotyczących odpowiedzialności za zgubione, zniszczone lub przełożone w inne miejsce przedmioty.

### Efekty:
Każdy odpowiada za swoje rzeczy. Ograniczenie możliwych konfliktów wynikających z własności i odpowiedzialności.

### Efekty, jeśli nie:
Brak jednoznacznych zasad, ryzyko konfliktów, utrudnienia w korzystaniu z przestrzeni biura.