### PR TITLE
2027/P001 - KONSTYTUCYJNA GWARANCJA KONTRPROPOZALI

### DIFF
--- a/src/content/docs/solvro/Statute.mdx
+++ b/src/content/docs/solvro/Statute.mdx
@@ -275,8 +275,8 @@ description: Regulamin KN Solvro
 4. O obradach Zgromadzenia Zarząd zawiadamia Członków co najmniej 14 dni przed terminem Walnego Zgromadzenia Członków. Zawiadomienie:  
    4.1 Jest publikowane na oficjalnych kanałach komunikacyjnych Organizacji.  
    4.2 Wskazuje datę, godzinę, miejsce, a także porządek obrad.  
-   4.3 Określa termin i sposób zgłaszania kandydatów do Zarządu.  
-   4.4 Określa termin i sposób zgłaszania propozycji zmian w regulaminie.  
+   4.3 Określa termin, sposób oraz formę zgłaszania kandydatów do Zarządu.  
+   4.4 Określa termin, sposób oraz formę zgłaszania propozycji zmian w regulaminie oraz kontrpropozycji do tych propozycji. Ostateczny termin zgłaszania propozycji musi być conajmniej 3 dni przed ostatecznym terminem zgłaszania kontrpropozycji, aby każdy członek miał równą i sprawiedliwą szansę na zapoznanie się z proponowanymi zmianami i zgłoszenia kontrpropozycji.  
    4.5 Zawiera informację o aktualnej liście członków uprawnionych do głosowania.
 
 5. Na Zgromadzeniu każdemu Aktywnemu Członkowi (z zastrzeżeniem § 5 ust. 9) przysługuje jeden głos.


### PR DESCRIPTION
## Opis
Propozycja gwarantuje członkom możliwość zgłaszania kontrpropozycji do proponowanych zmian w regulaminie. Wprowadza obowiązek określenia nie tylko terminu i sposobu zgłaszania propozycji zmian, ale także formy zgłaszania kontrpropozycji oraz odpowiedniego odstępu czasowego między tymi terminami. Dodatkowo gwarantuje istnienie takiej instytucji. 

## Cel / Uzasadnienie
Na ostatnim walnym nie było kontrproposali i było tragicznie

## Efekty, jeśli przyjęty
Członkowie będą mieli zagwarantowaną możliwość zgłaszania kontrpropozycji do zmian w regulaminie. Proces zmiany regulaminu stanie się bardziej przejrzysty, sprawiedliwy i odporny na jednostronne forsowanie zmian oraz umożliwy sensowną dyskusję i zgłaszanie alternatyw w sposób dokładny przed walnym zgromadzeniem.

## Efekty, jeśli odrzucony
Regulamin nadal nie będzie gwarantował członkom realnej możliwości zgłaszania kontrpropozycji. W praktyce może to utrudniać przygotowanie alternatywnych rozwiązań i ograniczać debatę nad zmianami regulaminowymi.