### PR TITLE
2027/P003 - OGRANICZENIE NADAWANIA CZŁONKOSTWA HONOROWEGO CZŁONKOM ZARZĄDU

### DIFF
--- a/src/content/docs/solvro/Statute.mdx
+++ b/src/content/docs/solvro/Statute.mdx
@@ -123,6 +123,10 @@ description: Regulamin KN Solvro
 
 7. Członkostwo Honorowe nabywa się na prośbę danej osoby, uznaniowo poprzez uchwałę Zarządu, za znaczny wkład w działalność Koła.
 
+7a. Członkostwo Honorowe nie może zostać nadane osobie pełniącej funkcję członka Zarządu ani osobie, która pełniła tę funkcję w okresie 3 miesięcy poprzedzających podjęcie uchwały o nadaniu Członkostwa Honorowego. W przypadku członków ustępującego Zarządu uchwałę o nadaniu Członkostwa Honorowego może podjąć dopiero Zarząd kolejnej kadencji lub jeden z następnych Zarządów.
+
+7b. Członkostwo Honorowe może zostać nadane osobie, która pełniła funkcję członka Zarządu, wyłącznie pod warunkiem wykonania przez nią obowiązków wynikających z niniejszego regulaminu, w szczególności obowiązków związanych z przekazaniem władzy, 2-miesięcznym okresem przejściowym oraz sprawozdaniem z kadencji.
+
 8. Kompetencje Członka Honorowego KN Solvro (z zastrzeżeniem ust. 9):  
    8.1. Możliwość korzystania z zasobów Koła, w tym sprzętu, materiałów oraz wsparcia merytorycznego w ramach działalności KN Solvro.  
    8.2. Prawo udziału w Walnych Zgromadzeniach Członków z wyłączeniem prawa do głosowania.  


### PR DESCRIPTION
## Opis
Propozycja wprowadza ograniczenie możliwości nadania Członkostwa Honorowego osobom pełniącym funkcję członka Zarządu oraz osobom, które pełniły tę funkcję w okresie 3 miesięcy poprzedzających podjęcie uchwały.


## Cel / Uzasadnienie
Celem jest ograniczenie konfliktu interesów przy nadawaniu Członkostwa Honorowego. Zarząd nie powinien mieć możliwości przyznawania takiego wyróżnienia samemu sobie.



## Efekty, jeśli przyjęty
Członkostwo Honorowe nie będzie mogło zostać nadane osobie pełniącej funkcję członka Zarządu ani osobie, która pełniła tę funkcję w okresie 3 miesięcy przed podjęciem uchwały.

Członkowie ustępującego Zarządu będą mogli otrzymać Członkostwo Honorowe dopiero decyzją kolejnego lub jednego z następnych Zarządów, pod warunkiem wykonania obowiązków wynikających z regulaminu.

Proces nadawania Członkostwa Honorowego stanie się bardziej przejrzysty, odporny na konflikt interesów i powiązany z realnym rozliczeniem kończącej się kadencji.

## Efekty, jeśli odrzucony
Regulamin nadal będzie pozwalał na sytuację, w której Zarząd może przyznać Członkostwo Honorowe samemu sobie.

Może to prowadzić do konfliktu interesów, obniżać wiarygodność wyróżnienia oraz osłabiać motywację do rzetelnego przekazania władzy i przygotowania sprawozdania z kadencji.