### PR TITLE
2027/P003-K001 SKŁADKA SANKCYJNA ZA OPÓŹNIENIE W PODSUMOWANIU KADENCJI

### DIFF
--- a/src/content/docs/solvro/Statute.mdx
+++ b/src/content/docs/solvro/Statute.mdx
@@ -57,6 +57,8 @@ description: Regulamin KN Solvro
     d. raport mierników określonych w strategii,  
     e. wnioski i rekomendacje dla następców.
 
+   W przypadku niezachowania terminu sporządzenia pierwszej wersji podsumowania kadencji członkowie ustępującego Zarządu są zobowiązani solidarnie do uiszczenia obowiązkowej składki sankcyjnej w wysokości 100 zł za każdy rozpoczęty miesiąc zwłoki. Formę i termin uiszczenia składki określa kolejny Zarząd w drodze uchwały. Do czasu uiszczenia należnej składki sankcyjnej Członkostwo Honorowe nie może zostać nadane osobie, która była członkiem ustępującego Zarządu. W przypadku wystąpienia przyczyn losowych wysokość składki sankcyjnej może zostać obniżona albo jej pobranie może zostać całkowicie uchylone jednomyślną uchwałą kolejnego Zarządu albo zwykłą uchwałą Walnego Zgromadzenia Członków.
+
    3.2. Osób sprawujących funkcje kierownicze, które w terminie do jednego miesiąca od zakończenia danego działania (projektu, wydarzenia, inicjatywy, kadencji) są zobowiązane do sporządzenia i udokumentowania ewaluacji zawierającej:  
     a. przebieg działań,  
     b. przepływ środków finansowych i materialnych,  
@@ -83,7 +85,8 @@ description: Regulamin KN Solvro
    2.2. Środki pozyskane poprzez zawarcie umów z innymi podmiotami.  
    2.3. Dobrowolne składki członkowskie.  
    2.4. Nagrody uzyskane w konkursach.  
-   2.5. Darowizny od osób fizycznych lub prawnych.
+   2.5. Darowizny od osób fizycznych lub prawnych.  
+   2.6. Obowiązkowe składki sankcyjne przewidziane niniejszym regulaminem.
 
 3. Zasady dobrowolnej składki członkowskiej:  
    3.1. Wysokość minimalnej dobrowolnej składki członkowskiej ustalana jest w drodze uchwały Zarządu lub Walnego Zgromadzenia. Członek może wpłacić dowolną kwotę nie niższą niż ustalona minimalna wysokość.  


### PR DESCRIPTION
## Opis
Kontrpropozycja wprowadza obowiązkową składkę sankcyjną za opóźnienie w sporządzeniu pierwszej wersji podsumowania kadencji przez ustępujący Zarząd.


## Cel / Uzasadnienie
Propozycja działa jako mechanizm dyscyplinujący: opóźnienie w przygotowaniu podsumowania ma konkretną konsekwencję finansową oraz blokuje możliwość uzyskania Członkostwa Honorowego do czasu uregulowania należności.

Jednocześnie propozycja przewiduje bezpiecznik na wypadek sytuacji losowych, ponieważ kolejny Zarząd może jednomyślnie obniżyć albo anulować składkę.

## Efekty, jeśli przyjęty
Ustępujący Zarząd będzie miał silniejszą motywację do terminowego przygotowania podsumowania kadencji.

## Efekty, jeśli odrzucony
Regulamin nadal będzie przewidywał obowiązek sporządzenia podsumowania kadencji, ale bez konkretnej sankcji za jego nieterminowe wykonanie. Bedąc w praktyce pustym zapisem.