### PR TITLE
2027/P003-K002 SKŁADKA SANKCYJNA ZA OPÓŹNIENIE W PLANIE KADENCJI

### DIFF
--- a/src/content/docs/solvro/Statute.mdx
+++ b/src/content/docs/solvro/Statute.mdx
@@ -50,6 +50,8 @@ description: Regulamin KN Solvro
     d. preliminarz budżetowy,  
     e. zestawienie obecnych zasobów ludzkich, projektowych, materialnych i finansowych.
 
+   W przypadku niezachowania terminu przedstawienia i udostępnienia członkom planu kadencji członkowie Zarządu, który nie dochował tego terminu, są zobowiązani solidarnie do uiszczenia obowiązkowej składki sankcyjnej w wysokości 100 zł za każdy rozpoczęty miesiąc zwłoki. Formę i termin uiszczenia składki określa kolejny Zarząd w drodze uchwały. Do czasu uiszczenia należnej składki sankcyjnej Członkostwo Honorowe nie może zostać nadane osobie, która była członkiem Zarządu, który nie dochował terminu. W przypadku wystąpienia przyczyn losowych wysokość składki sankcyjnej może zostać obniżona albo jej pobranie może zostać całkowicie uchylone jednomyślną uchwałą kolejnego Zarządu albo zwykłą uchwałą Walnego Zgromadzenia Członków.
+
    Najpóźniej do dnia przekazania władzy, Zarząd sporządza pierwszą wersję podsumowania kadencji, obejmujące:  
     a. ewaluację działań, w szczególności w ramach planu kadencji,  
     b. inwentaryzację zasobów ludzkich, materialnych, projektowych i finansowych,  
@@ -83,7 +85,8 @@ description: Regulamin KN Solvro
    2.2. Środki pozyskane poprzez zawarcie umów z innymi podmiotami.  
    2.3. Dobrowolne składki członkowskie.  
    2.4. Nagrody uzyskane w konkursach.  
-   2.5. Darowizny od osób fizycznych lub prawnych.
+   2.5. Darowizny od osób fizycznych lub prawnych.  
+   2.6. Obowiązkowe składki sankcyjne przewidziane niniejszym regulaminem.
 
 3. Zasady dobrowolnej składki członkowskiej:  
    3.1. Wysokość minimalnej dobrowolnej składki członkowskiej ustalana jest w drodze uchwały Zarządu lub Walnego Zgromadzenia. Członek może wpłacić dowolną kwotę nie niższą niż ustalona minimalna wysokość.  


### PR DESCRIPTION
## Opis
Kontrpropozycja wprowadza obowiązkową składkę sankcyjną za opóźnienie w przedstawieniu i udostępnieniu członkom planu kadencji przez Zarząd.

## Cel / Uzasadnienie
Propozycja działa jako mechanizm dyscyplinujący: opóźnienie w przygotowaniu planu kadencji ma konkretną konsekwencję finansową oraz blokuje możliwość uzyskania Członkostwa Honorowego do czasu uregulowania należności.

Jednocześnie propozycja przewiduje bezpiecznik na wypadek sytuacji losowych, ponieważ składka może zostać obniżona albo uchylona jednomyślną uchwałą kolejnego Zarządu albo zwykłą uchwałą Walnego Zgromadzenia Członków.

## Efekty, jeśli przyjęty
Zarząd będzie miał silniejszą motywację do terminowego przedstawienia i udostępnienia członkom planu kadencji.

## Efekty, jeśli odrzucony
Regulamin nadal będzie przewidywał obowiązek przedstawienia planu kadencji, ale bez konkretnej sankcji za jego nieterminowe wykonanie. Będzie to w praktyce osłabiało skuteczność tego obowiązku.