### PR TITLE
2027/P004 - GŁOSOWANIE DWUTUROWE W WYBORACH DO ZARZĄDU

### DIFF
--- a/src/content/docs/solvro/Statute.mdx
+++ b/src/content/docs/solvro/Statute.mdx
@@ -249,7 +249,7 @@ description: Regulamin KN Solvro
 
    8b. Jeżeli na dane miejsce w Zarządzie kandydują dwie osoby, wybrany zostaje kandydat, który uzyskał większą liczbę głosów niż drugi kandydat. Głosy nieważne traktuje się jak głosy wstrzymujące się.
 
-   8c. Jeżeli na dane miejsce w Zarządzie kandydują więcej niż dwie osoby, przeprowadza się głosowanie dwuturowe. Do drugiej tury przechodzą dwaj kandydaci, którzy w pierwszej turze uzyskali największą liczbę głosów.
+   8c. Jeżeli na dane miejsce w Zarządzie kandydują więcej niż dwie osoby, przeprowadza się głosowanie dwuturowe. Jeżeli w pierwszej turze kandydat uzyska więcej niż 50% oddanych głosów, zostaje wybrany bez przeprowadzania drugiej tury. W przeciwnym przypadku do drugiej tury przechodzą dwaj kandydaci, którzy w pierwszej turze uzyskali największą liczbę głosów.
 
    8d. W drugiej turze wybrany zostaje kandydat, który uzyskał większą liczbę głosów niż drugi kandydat. Głosy nieważne traktuje się jak głosy wstrzymujące się.
 

--- a/src/content/docs/solvro/Statute.mdx
+++ b/src/content/docs/solvro/Statute.mdx
@@ -245,6 +245,14 @@ description: Regulamin KN Solvro
 
 8. Wybór Członków Zarządu odbywa się w głosowaniu bezpośrednim, równym i tajnym, zwykłą większością głosów przy obecności przynajmniej 1/2 Aktywnych Członków (z zastrzeżeniem § 5 ust. 9) podczas Walnego Zgromadzenia Członków.
 
+   8a. Jeżeli na dane miejsce w Zarządzie kandyduje jedna osoba, głosowanie odbywa się poprzez oddanie głosu „za”, „przeciw” albo „wstrzymującego się”. Kandydat zostaje wybrany, jeżeli liczba głosów „za” jest większa niż liczba głosów „przeciw”. Głosy nieważne traktuje się jak głosy wstrzymujące się.
+
+   8b. Jeżeli na dane miejsce w Zarządzie kandydują dwie osoby, wybrany zostaje kandydat, który uzyskał większą liczbę głosów niż drugi kandydat. Głosy nieważne traktuje się jak głosy wstrzymujące się.
+
+   8c. Jeżeli na dane miejsce w Zarządzie kandydują więcej niż dwie osoby, przeprowadza się głosowanie dwuturowe. Do drugiej tury przechodzą dwaj kandydaci, którzy w pierwszej turze uzyskali największą liczbę głosów.
+
+   8d. W drugiej turze wybrany zostaje kandydat, który uzyskał większą liczbę głosów niż drugi kandydat. Głosy nieważne traktuje się jak głosy wstrzymujące się.
+
 9. Oficjalne i pełne przekazanie władzy nowo wybranemu Zarządowi następuje najpóźniej 12 miesięcy od dnia objęcia władzy poprzez poprzedni Zarząd i nie później niż miesiąc od dnia wyboru nowego Zarządu. Konkretną datę dzienną ustala Zarząd w drodze uchwały, a następnie zawiadamia o niej Członków Koła, najpóźniej w dniu wyboru nowego Zarządu.
 
    9a. Po oficjalnym przekazaniu władzy członkowie ustępującego Zarządu są zobowiązani do pozostania dostępnymi dla nowego Zarządu przez okres co najmniej 2 miesięcy. W tym czasie udzielają wsparcia merytorycznego w zakresie pełnionych wcześniej funkcji, w szczególności dotyczącego spraw niezakończonych w trakcie kadencji. Obowiązek ten ma charakter indywidualny i spoczywa na każdym członku ustępującego Zarządu, w granicach jego obszaru odpowiedzialności. Ustępujący Prezes pozostaje dodatkowo punktem kontaktowym dla nowego Zarządu w sprawach wymagających wiedzy o całokształcie działalności Koła.


### PR DESCRIPTION
## Opis
Propozycja doprecyzowuje sposób wyboru Członków Zarządu w zależności od liczby kandydatów na dane miejsce w Zarządzie.

## Cel / Uzasadnienie
Aktualnie nie da się wygrać przy ponad 2 kandydatach na pozyzcję. naszczęscie jeszcze nigdy tylu nie było :P

## Efekty, jeśli przyjęty
Regulamin będzie jasno określał sposób wyboru Członków Zarządu przy jednym, dwóch oraz większej liczbie kandydatów.


## Efekty, jeśli odrzucony
Regulamin nadal będzie zawierał ogólną zasadę wyboru zwykłą większością głosów, bez doprecyzowania sposobu postępowania przy różnej liczbie kandydatów.
